### PR TITLE
Use node:18 base Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ dist
 node_modules
 screenshots
 package-lock.json
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+screenshots/
+package-lock.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-dist/
-node_modules/
-screenshots/
+dist
+node_modules
+screenshots
 package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.11.1-bullseye-slim
+FROM node:18
 
 ENV USER=mannele
 


### PR DESCRIPTION
There should be no compatibility issue with Node 18 and I have been running Mannele on this version for quite some time now without any issue. 

Changes:
- Use `node:18` Docker image
- This commit also adds some entries in `.dockerignore`, this is in order to gain deployment efficiency.