### PR TITLE
Add fly.toml file

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,14 @@
+# fly.toml file generated for mannele on 2022-07-15T22:08:35+02:00
+
+app = "mannele"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]


### PR DESCRIPTION
This is a configuration file for deployment on fly.io, it disables TCP/HTTP healthchecks since the bot doesn't open a server and is instead a client to the Discord API.