### PR TITLE
Use "rolling" deploy strategy on fly.io

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,9 @@ kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []
 
+[deploy]
+strategy = "rolling"
+
 [env]
 
 [experimental]


### PR DESCRIPTION
This should prevent two instances from running at the same time, which could cause issues.