### PR TITLE
Use release command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,29 @@
 FROM node:18
 
 ENV USER=mannele
+ARG DEPLOY_COMMANDS=YES
 
 RUN npm install -g typescript
 
 RUN groupadd -r ${USER} && \
-        useradd --create-home --home /home/mannele -r -g ${USER} ${USER}
+    useradd --create-home --home /home/mannele -r -g ${USER} ${USER}
 
 USER ${USER}
 WORKDIR /home/mannele
 
 COPY --chown=${USER}:${USER} . ./
 
-RUN npm install && \
-    tsc && \
-    node dist/deploy-commands.js
+RUN npm install
+RUN tsc
 
-ENTRYPOINT [ "node", "dist/main.js" ]
+# By default, we will run the Discord command deploy script, however in some cases
+# we may not want to do this as part of a build step (such as when building on fly.io)
+# so it can be disabled by setting the DEPLOY_COMMANDS variable to NO.
+RUN if [ "${DEPLOY_COMMANDS}" = "YES" ]; then node dist/deploy-commands.js; fi
+
+
+ENTRYPOINT [ "node" ]
+
+# Not putting the following as an ENTRYPOINT argument because some hosting providers
+# use the ENTRYPOINT to do other things, so specifying it as an argument would break them.
+CMD [ "dist/main.js" ]

--- a/fly.toml
+++ b/fly.toml
@@ -5,8 +5,14 @@ kill_signal = "SIGINT"
 kill_timeout = 5
 processes = []
 
+[build.args]
+# We don't want to the build process to deploy the Discord commands
+# Instead we do this with the release_command below
+  DEPLOY_COMMANDS="NO"
+
 [deploy]
-strategy = "rolling"
+  strategy = "rolling"
+  release_command = "dist/deploy-commands.js"
 
 [env]
 


### PR DESCRIPTION
This changes the Dockerfile and fly.toml file to enable not deploying on build.
This is required in some situations where the build process may not have access to the environment variables in order to properly call the Discord API.

What we are doing here is that we enable using the DEPLOY_COMMANDS Docker argument to control wether the build process should deploy or not.
Currently, DEPLOY_COMMANDS is set to YES by default, but this may change in future releases so it's better to start specifying it explicitly.

The fly.toml file has been changed to include a release_command thatcalls the deploy script.

It was important that the ENTRYPOINT was just node, because fly.io uses the entrypoint to run the release_command and so anything specified along the ENTRYPOINT would also be run (so we don't want to start the bot from release_command, we just want to deploy).