### PR TITLE
Create a repeating task for fetching stops and address data

### DIFF
--- a/CTSService.ts
+++ b/CTSService.ts
@@ -225,11 +225,11 @@ export class CTSService {
         });
 
         let queryResults =  await CTSService.loadStopCodesMap(ctsAPI);
-        
+
         return new CTSService(ctsAPI, queryResults);
     }
 
-    static async loadStopCodesMap(ctsAPI: AxiosInstance): Promise<Map<string, StationQueryResult> {
+    static async loadStopCodesMap(ctsAPI: AxiosInstance): Promise<Map<string, StationQueryResult>> {
         let geoGouvAPI = axios.create({
             baseURL: "https://api-adresse.data.gouv.fr",
             timeout: 8000,

--- a/CTSService.ts
+++ b/CTSService.ts
@@ -375,6 +375,21 @@ export class CTSService {
                 queryResults = savedResults.map;
                 process.env.LAST_STOP_UPDATE =
                     savedResults.date.toLocaleDateString("fr-FR");
+
+            // Same as above but this time store full date + time using the argument of the function
+            process.env.LAST_STOP_UPDATE = savedResults.date.toLocaleDateString(
+                "fr-FR",
+                {
+                    year: "numeric",
+                    month: "2-digit",
+                    day: "2-digit",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    hour12: false,
+                    timeZone: "Europe/Paris"
+                }
+            )
+
             } else {
                 throw new Error(`Couldn't recover from error`);
             }

--- a/CTSService.ts
+++ b/CTSService.ts
@@ -224,7 +224,7 @@ export class CTSService {
             timeout: 8000,
         });
 
-        let queryResults =  await CTSService.loadStopCodesMap(ctsAPI);
+        let queryResults = await CTSService.loadStopCodesMap(ctsAPI);
 
         return new CTSService(ctsAPI, queryResults);
     }
@@ -373,22 +373,8 @@ export class CTSService {
             );
             if (savedResults !== undefined) {
                 queryResults = savedResults.map;
-                process.env.LAST_STOP_UPDATE =
-                    savedResults.date.toLocaleDateString("fr-FR");
-
-            // Same as above but this time store full date + time using the argument of the function
-            process.env.LAST_STOP_UPDATE = savedResults.date.toLocaleDateString(
-                "fr-FR",
-                {
-                    year: "numeric",
-                    month: "2-digit",
-                    day: "2-digit",
-                    hour: "2-digit",
-                    minute: "2-digit",
-                    hour12: false,
-                    timeZone: "Europe/Paris"
-                }
-            )
+                // Same as above but this time store full date + time using the argument of the function
+                process.env.LAST_STOP_UPDATE = CTSService.formatDateFR(savedResults.date)
 
             } else {
                 throw new Error(`Couldn't recover from error`);
@@ -397,6 +383,29 @@ export class CTSService {
 
         return queryResults
     }
+
+    /**
+     * Format a date in the "dd/mm/yyyy à hh:mm (heure de Paris)" format
+     * @param date Date to format
+     */
+    static formatDateFR(date: Date): string {
+        const dateString = date.toLocaleDateString("fr-FR", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            timeZone: "Europe/Paris"
+        });
+
+        const timeString = date.toLocaleTimeString("fr-FR", {
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+            timeZone: "Europe/Paris"
+        });
+
+        return `${dateString} à ${timeString} (heure de Paris)`;
+    }
+
 
     static async getAddressDescription(
         axiosInstance: AxiosInstance,
@@ -562,7 +571,7 @@ export class CTSService {
             try {
                 let schedule = await this.getVisitsForStopCode([stopCode]);
                 result.push([stopCode, schedule]);
-            } catch (e) {}
+            } catch (e) { }
         }
         return result;
     }
@@ -625,11 +634,11 @@ export class CTSService {
                         resultVisits.findIndex((resultSchedule) => {
                             return (
                                 resultSchedule.name ===
-                                    elementToMergeVisit.name &&
+                                elementToMergeVisit.name &&
                                 resultSchedule.transportType ===
-                                    elementToMergeVisit.transportType &&
+                                elementToMergeVisit.transportType &&
                                 resultSchedule.destinationName ===
-                                    elementToMergeVisit.destinationName &&
+                                elementToMergeVisit.destinationName &&
                                 resultSchedule.via === elementToMergeVisit.via
                             );
                         }) != -1

--- a/CTSService.ts
+++ b/CTSService.ts
@@ -224,6 +224,12 @@ export class CTSService {
             timeout: 8000,
         });
 
+        let queryResults =  await CTSService.loadStopCodesMap(ctsAPI);
+        
+        return new CTSService(ctsAPI, queryResults);
+    }
+
+    static async loadStopCodesMap(ctsAPI: AxiosInstance): Promise<Map<string, StationQueryResult> {
         let geoGouvAPI = axios.create({
             baseURL: "https://api-adresse.data.gouv.fr",
             timeout: 8000,
@@ -351,6 +357,7 @@ export class CTSService {
                 "./resources/last-query-results.json",
                 savedResults
             );
+
         } catch (e) {
             if (e instanceof Error && e.message === "LOAD_FROM_CACHE") {
                 console.log("Loading from cache");
@@ -373,7 +380,7 @@ export class CTSService {
             }
         }
 
-        return new CTSService(ctsAPI, queryResults);
+        return queryResults
     }
 
     static async getAddressDescription(

--- a/CTSService.ts
+++ b/CTSService.ts
@@ -460,6 +460,12 @@ export class CTSService {
     // normalized stop names
     private stopCodes: Map<string, StationQueryResult> = new Map();
 
+
+    // Async function updateStopCodes()
+    async updateStopCodes() {
+        this.stopCodes = await CTSService.getStopCodes(this.api);
+    }
+    
     async getFormattedSchedule(
         userReadableName: string,
         stopCodes: string[],

--- a/CTSService.ts
+++ b/CTSService.ts
@@ -463,9 +463,9 @@ export class CTSService {
 
     // Async function updateStopCodes()
     async updateStopCodes() {
-        this.stopCodes = await CTSService.getStopCodes(this.api);
+        this.stopCodes = await CTSService.loadStopCodesMap(this.api);
     }
-    
+
     async getFormattedSchedule(
         userReadableName: string,
         stopCodes: string[],

--- a/CTSService.ts
+++ b/CTSService.ts
@@ -357,6 +357,7 @@ export class CTSService {
                 "./resources/last-query-results.json",
                 savedResults
             );
+            process.env.LAST_STOP_UPDATE = CTSService.formatDateFR(saveData.date)
 
         } catch (e) {
             if (e instanceof Error && e.message === "LOAD_FROM_CACHE") {

--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,18 @@ require("dotenv").config();
     const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 
     // Set environement variable LAST_STOP_UPDATE to dd/mm/yyyy
-    process.env.LAST_STOP_UPDATE = new Date().toLocaleDateString("fr-FR");
+    process.env.LAST_STOP_UPDATE = new Date().toLocaleDateString(
+        "fr-FR",
+        {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+            timeZone: "Europe/Paris"
+        }
+    )
 
     // Store token in a variable from the DISCORD_TOKEN environment variable
     const token = process.env.DISCORD_TOKEN;

--- a/main.ts
+++ b/main.ts
@@ -63,14 +63,14 @@ require("dotenv").config();
         await StatsService.load("./stats/", statsSlotCount, excludedIDs)
     );
 
-    // Update every 2 minutes
+    // Update every 6 hours
     setInterval(async () => {
         try {
             await botServices.cts.updateStopCodes()
         } catch (e) {
             console.error("Couldn't update stop codes", e)
         }
-    }, 1000 * 60 * 2);
+    }, 1000 * 60 * 60 * 6);
 
     // Create a collection associating command (and subcommand) names with their executors
     const commands = new Collection<string, CommandDescriptor>();

--- a/main.ts
+++ b/main.ts
@@ -11,19 +11,8 @@ require("dotenv").config();
 (async () => {
     const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
 
-    // Set environement variable LAST_STOP_UPDATE to dd/mm/yyyy
-    process.env.LAST_STOP_UPDATE = new Date().toLocaleDateString(
-        "fr-FR",
-        {
-            year: "numeric",
-            month: "2-digit",
-            day: "2-digit",
-            hour: "2-digit",
-            minute: "2-digit",
-            hour12: false,
-            timeZone: "Europe/Paris"
-        }
-    )
+    // Set environement variable LAST_STOP_UPDATE to the proper formatted string
+    process.env.LAST_STOP_UPDATE = CTSService.formatDateFR(new Date())
 
     // Store token in a variable from the DISCORD_TOKEN environment variable
     const token = process.env.DISCORD_TOKEN;

--- a/main.ts
+++ b/main.ts
@@ -10,10 +10,6 @@ require("dotenv").config();
 
 (async () => {
     const client = new Client({ intents: [Intents.FLAGS.GUILDS] });
-
-    // Set environement variable LAST_STOP_UPDATE to the proper formatted string
-    process.env.LAST_STOP_UPDATE = CTSService.formatDateFR(new Date())
-
     // Store token in a variable from the DISCORD_TOKEN environment variable
     const token = process.env.DISCORD_TOKEN;
 
@@ -67,14 +63,14 @@ require("dotenv").config();
         await StatsService.load("./stats/", statsSlotCount, excludedIDs)
     );
 
-    // Update every 5 minutes
+    // Update every 2 minutes
     setInterval(async () => {
         try {
             await botServices.cts.updateStopCodes()
         } catch (e) {
             console.error("Couldn't update stop codes", e)
         }
-    }, 1000 * 60 * 5);
+    }, 1000 * 60 * 2);
 
     // Create a collection associating command (and subcommand) names with their executors
     const commands = new Collection<string, CommandDescriptor>();

--- a/main.ts
+++ b/main.ts
@@ -67,6 +67,15 @@ require("dotenv").config();
         await StatsService.load("./stats/", statsSlotCount, excludedIDs)
     );
 
+    // Update every 5 minutes
+    setInterval(async () => {
+        try {
+            await botServices.cts.updateStopCodes()
+        } catch (e) {
+            console.error("Couldn't update stop codes", e)
+        }
+    }, 1000 * 60 * 5);
+
     // Create a collection associating command (and subcommand) names with their executors
     const commands = new Collection<string, CommandDescriptor>();
 


### PR DESCRIPTION
Currently, this data is only fetched on bot startup, which is ok with process managers such as PM2, however some hosting platforms make using PM2 redundant, therefore there needs to be a better way to fetch the data without relying on a process restart.

Resolves #35 