### PR TITLE
Use a fixed version of TypeScript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM node:18
 ENV USER=mannele
 ARG DEPLOY_COMMANDS=YES
 
-RUN npm install -g typescript
-
 RUN groupadd -r ${USER} && \
     useradd --create-home --home /home/mannele -r -g ${USER} ${USER}
 
@@ -14,7 +12,7 @@ WORKDIR /home/mannele
 COPY --chown=${USER}:${USER} . ./
 
 RUN npm install
-RUN tsc
+RUN npx tsc
 
 # By default, we will run the Discord command deploy script, however in some cases
 # we may not want to do this as part of a build step (such as when building on fly.io)


### PR DESCRIPTION
Using a global install didn't respect what was being specified in package.json and package-lock.json, which could cause unexpected build issues as new TypeScript versions get published